### PR TITLE
Fix widget test and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Flutter/Dart/Pub related
+**/build/
+.dart_tool/
+.packages
+.pub-cache/
+.pub/
+flutter/
+pubspec.lock
+
+# Visual Studio Code
+.vscode/
+
+# IDE files
+.idea/
+

--- a/README.md
+++ b/README.md
@@ -92,7 +92,13 @@ lib/
 
 ## 🧪 Testing
 
-Run tests using the following commands:
+Run tests after fetching dependencies:
+
+```bash
+flutter pub get
+```
+
+Then run the tests with:
 
 ```bash
 # Run all tests

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import '../features/home/home_page.dart';
+
+class PartoMatApp extends StatelessWidget {
+  const PartoMatApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'PartoMat',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const HomePage(),
+    );
+  }
+}

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('PartoMat'),
+      ),
+      body: const Center(
+        child: Text('Welcome to PartoMat!'),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/material.dart';
+import 'app/app.dart';
+
+void main() {
+  runApp(const PartoMatApp());
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,19 @@
+name: partomat_flutter
+description: A Flutter automotive parts marketplace app
+version: 0.1.0
+publish_to: none
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true
+

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:partomat_flutter/app/app.dart';
+
+void main() {
+  testWidgets('Home page shows welcome text', (WidgetTester tester) async {
+    await tester.pumpWidget(const PartoMatApp());
+
+    expect(find.text('Welcome to PartoMat!'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- clarify instructions for running tests
- basic Flutter skeleton code for `PartoMatApp` with a HomePage widget

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6842cbab69dc8328826572798df1de63